### PR TITLE
Fix anchor links in docs

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -3,7 +3,7 @@
 ## Table of Contents
 
 - [Compiling Zap From Source](#compiling-zap-from-source)
-- [Lightning Network Daemon (lnd)](<#lightning-network-daemon-(lnd)>)
+- [Lightning Network Daemon (lnd)](<#lightning-network-daemon-lnd>)
 - [Running Zap](#running-zap)
 
 ## Compiling Zap From Source

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -4,7 +4,7 @@
 
 - [Compiling Zap From Source](#Compiling-Zap-From-Source)
 - [Lightning Network Daemon (lnd)](<#Lightning-Network-Daemon-(lnd)>)
-- [Running Zap](#Running-Zap)
+- [Running Zap](#running-zap)
 
 ## Compiling Zap From Source
 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -2,8 +2,8 @@
 
 ## Table of Contents
 
-- [Compiling Zap From Source](#Compiling-Zap-From-Source)
-- [Lightning Network Daemon (lnd)](<#Lightning-Network-Daemon-(lnd)>)
+- [Compiling Zap From Source](#compiling-zap-from-source)
+- [Lightning Network Daemon (lnd)](<#lightning-network-daemon-(lnd)>)
 - [Running Zap](#running-zap)
 
 ## Compiling Zap From Source


### PR DESCRIPTION
The anchor links on the Advanced Usage Page weren't working in Chrome in Ubuntu. Making them lower case and removing the parentheses seems to solve the problem.